### PR TITLE
Small Refactoring + Memory Leak

### DIFF
--- a/SYPictureMetadata/SYMetadata.m
+++ b/SYPictureMetadata/SYMetadata.m
@@ -42,10 +42,7 @@
 {
     if(self = [super init])
     {
-        self->_asset = nil;
-        self->_assetURL = nil;
-        self->_absolutePathURL = nil;
-        self->_metadata = metadata;
+        _metadata = metadata;
         [self refresh:NO];
     }
     return self;
@@ -55,10 +52,7 @@
 {
     if(self = [super init])
     {
-        self->_asset = asset;
-        self->_assetURL = nil;
-        self->_absolutePathURL = nil;
-        self->_metadata = nil;
+        _asset = asset;
         [self refresh:NO];
     }
     return self;
@@ -68,10 +62,7 @@
 {
     if(self = [super init])
     {
-        self->_asset = nil;
-        self->_assetURL = assetURL;
-        self->_absolutePathURL = nil;
-        self->_metadata = nil;
+        _assetURL = assetURL;
         [self refresh:NO];
     }
     return self;
@@ -81,11 +72,8 @@
 {
     if(self = [super init])
     {
-        self->_asset = nil;
-        self->_assetURL = nil;
-        self->_absolutePathURL = absolutePathURL;
-        self->_metadata = nil;
-        [self refresh:NO];
+        _absolutePathURL = absolutePathURL;
+        [self refresh:NO];        
     }
     return self;
 }

--- a/SYPictureMetadata/SYMetadataBase.m
+++ b/SYPictureMetadata/SYMetadataBase.m
@@ -12,22 +12,15 @@
 
 -(id)initWithDic:(NSDictionary*)dic
 {
+    if(!dic) return nil;
+    
     if(self = [super init])
     {
-        self->_dic = dic;
+        _dic = dic;
     }
-    
-    if(!dic)
-        return nil;
     
     return self;
 }
-
--(NSDictionary *)getDictionary
-{
-    return self->_dic;
-}
-
 
 -(NSObject *)objectForKeyString:(NSString *)key
 {
@@ -74,8 +67,8 @@
 -(NSArray*)arrayForKeyString:(NSString*)key
 {
     NSObject *obj = [self->_dic objectForKey:key];
-    BOOL isArray = [obj isKindOfClass:[NSArray class]];
-    if(!isArray && obj) {
+    BOOL isArray = [obj isKindOfClass:[NSArray class]]; // if obj == nil, expression will evaluate false.
+    if(!isArray) {
         NSLog(@"Wrong type for key \"%@\", not a array : %@", key, [[obj class] description]);
         return nil;
     }


### PR DESCRIPTION
- Removed unneeded initialisation on instance variables ([Instance variables are initialised to zero](http://developer.apple.com/library/ios/#documentation/general/conceptual/CocoaEncyclopedia/Initialization/Initialization.html)) and
- Fixed a memory leak when instantiating class SYMetadataBase with an empty NSDictionary.
