### PR TITLE
Declare support for macOS and visionOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,9 @@ let package = Package(
     name: "SYPictureMetadata",
     platforms: [
         .iOS(.v12),
-        .tvOS(.v12)
+        .tvOS(.v12),
+        .macOS(.v10_14),
+        .visionOS(.v1)
     ],
     products: [
         .library(name: "SYPictureMetadata", targets: ["SYPictureMetadata"]),


### PR DESCRIPTION
This just adds explicit support for macOS and visionOS in Package.swift. The package builds and the tests pass on both platforms.